### PR TITLE
virtual file should not register into output

### DIFF
--- a/src/resource/virtual_file.rs
+++ b/src/resource/virtual_file.rs
@@ -57,9 +57,8 @@ impl Build for VirtualFile {
         self,
         builder: &mut Builder,
     ) -> Result<(Option<PathBuf>, Dependency, Vec<Dependency>), Box<dyn std::error::Error>> {
-        let path = self.path.clone();
         let dependency = builder.make_dependency(self)?;
-        Ok((Some(path), dependency, vec![]))
+        Ok((None, dependency, vec![]))
     }
     fn generate(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         let VirtualFile { path, .. } = self;


### PR DESCRIPTION
This PR fixes a small bug where VirtualFile components were registered into the build output.