### PR TITLE
Use Registration to Signify Virtual/Concrete Resources

### DIFF
--- a/examples/basic/main.rs
+++ b/examples/basic/main.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 use blanket_rs::{
-    builder::{Build, Builder, Dependency},
+    builder::{Build, Builder, Dependency, Registration},
     resource::{CopyFile, Root},
 };
 
@@ -93,11 +93,11 @@ impl Build for CopyDir {
     fn register(
         self,
         builder: &mut Builder,
-    ) -> Result<(Option<PathBuf>, Dependency, Vec<Dependency>), Box<dyn std::error::Error>> {
+    ) -> Result<(Registration, Vec<Dependency>), Box<dyn std::error::Error>> {
         let path = self.path.clone();
         let dependency = builder.make_dependency(self)?;
         let root = builder.require(Root {})?;
-        Ok((Some(path), dependency, vec![root]))
+        Ok((Registration::Concrete(dependency, path), vec![root]))
     }
     fn generate(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         let CopyDir { source, .. } = self;

--- a/examples/blanket-rs-net/main.rs
+++ b/examples/blanket-rs-net/main.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 use blanket_rs::{
-    builder::{Build, Builder, Dependency},
+    builder::{Build, Builder, Dependency, Registration},
     resource::{CopyFile, Root},
 };
 
@@ -93,11 +93,11 @@ impl Build for CopyDir {
     fn register(
         self,
         builder: &mut Builder,
-    ) -> Result<(Option<PathBuf>, Dependency, Vec<Dependency>), Box<dyn std::error::Error>> {
+    ) -> Result<(Registration, Vec<Dependency>), Box<dyn std::error::Error>> {
         let path = self.path.clone();
         let dependency = builder.make_dependency(self)?;
         let root = builder.require(Root {})?;
-        Ok((Some(path), dependency, vec![root]))
+        Ok((Registration::Concrete(dependency, path), vec![root]))
     }
     fn generate(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         let CopyDir { source, .. } = self;

--- a/src/resource/copy.rs
+++ b/src/resource/copy.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
 use crate::{
-    builder::{Build, Builder, Dependency},
+    builder::{Build, Builder, Dependency, Registration},
     resource::Directory,
 };
 
@@ -43,7 +43,7 @@ impl Build for CopyFile {
     fn register(
         self,
         builder: &mut Builder,
-    ) -> Result<(Option<PathBuf>, Dependency, Vec<Dependency>), Box<dyn std::error::Error>> {
+    ) -> Result<(Registration, Vec<Dependency>), Box<dyn std::error::Error>> {
         let path = self.path.clone();
         let parent = match self.path.parent() {
             Some(parent) => parent,
@@ -51,7 +51,7 @@ impl Build for CopyFile {
         };
         let dir = builder.require(Directory::new(parent))?;
         let dependency = builder.make_dependency(self)?;
-        Ok((Some(path), dependency, vec![dir]))
+        Ok((Registration::Concrete(dependency, path), vec![dir]))
     }
     fn generate(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         let CopyFile { source, path } = self;

--- a/src/resource/directory.rs
+++ b/src/resource/directory.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
-use crate::builder::{Build, Builder, Dependency};
+use crate::builder::{Build, Builder, Dependency, Registration};
 use crate::resource::Root;
 
 #[derive(Debug)]
@@ -39,11 +39,11 @@ impl Build for Directory {
     fn register(
         self,
         builder: &mut Builder,
-    ) -> Result<(Option<PathBuf>, Dependency, Vec<Dependency>), Box<dyn std::error::Error>> {
+    ) -> Result<(Registration, Vec<Dependency>), Box<dyn std::error::Error>> {
         let path = self.path.clone();
         let dependency = builder.make_dependency(self)?;
         let root = builder.require(Root {})?;
-        Ok((Some(path), dependency, vec![root]))
+        Ok((Registration::Concrete(dependency, path), vec![root]))
     }
     fn generate(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         let Directory { path, .. } = self;

--- a/src/resource/root.rs
+++ b/src/resource/root.rs
@@ -1,4 +1,4 @@
-use crate::builder::{Build, Builder, Dependency};
+use crate::builder::{Build, Builder, Dependency, Registration};
 use std::cell::RefCell;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -26,9 +26,12 @@ impl Build for Root {
     fn register(
         self,
         builder: &mut Builder,
-    ) -> Result<(Option<PathBuf>, Dependency, Vec<Dependency>), Box<dyn std::error::Error>> {
+    ) -> Result<(Registration, Vec<Dependency>), Box<dyn std::error::Error>> {
         let dependency = builder.make_dependency(self)?;
-        Ok((Some(PathBuf::from("/")), dependency, vec![]))
+        Ok((
+            Registration::Concrete(dependency, PathBuf::from("/")),
+            vec![],
+        ))
     }
     fn generate(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         println!("Root::generate");

--- a/src/resource/virtual_file.rs
+++ b/src/resource/virtual_file.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
-use crate::builder::{Build, Builder, Dependency};
+use crate::builder::{Build, Builder, Dependency, Registration};
 
 pub struct VirtualFile {
     path: PathBuf,
@@ -56,9 +56,9 @@ impl Build for VirtualFile {
     fn register(
         self,
         builder: &mut Builder,
-    ) -> Result<(Option<PathBuf>, Dependency, Vec<Dependency>), Box<dyn std::error::Error>> {
+    ) -> Result<(Registration, Vec<Dependency>), Box<dyn std::error::Error>> {
         let dependency = builder.make_dependency(self)?;
-        Ok((None, dependency, vec![]))
+        Ok((Registration::Virtual(dependency), vec![]))
     }
     fn generate(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         let VirtualFile { path, .. } = self;


### PR DESCRIPTION
This PR adds a `Registration` enum which is used to explicitly mark resources as either `Virtual` or `Concrete`.

Addresses #8