### PR TITLE
Ignore Example Outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ Cargo.lock
 
 # Darwin
 .DS_Store
+
+# Example output
+examples/basic/site-out
+examples/blanket-rs-net/site-out


### PR DESCRIPTION
Adds example outputs to `.gitignore`.