### PR TITLE
RenderFile should not be Register

### DIFF
--- a/examples/blanket-rs-net/main.rs
+++ b/examples/blanket-rs-net/main.rs
@@ -26,8 +26,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     // create the generator
     // use the allow filter to protect from writing above the output directory
     let mut site = Generator::builder()
-        // .allow(vec![format!("{}/*", get_top_dir(&output)?).as_str()])
-        .allow(vec![format!("{}/*", output.to_string_lossy()).as_str()])
+        .allow(vec![format!("{}/.*", output.to_string_lossy()).as_str()])
         .build();
 
     // clear the output directory

--- a/src/generator/render.rs
+++ b/src/generator/render.rs
@@ -2,28 +2,17 @@ use std::cell::RefCell;
 use std::path::PathBuf;
 use std::rc::Rc;
 
-use crate::{html::Render, Generate, Register, Registration};
+use crate::{html::Render, Generate};
 
 pub struct RenderFile {
     element: Rc<RefCell<dyn Render>>,
-    destination: PathBuf,
 }
 
 impl RenderFile {
-    pub fn new(destination: &PathBuf, element: Rc<RefCell<dyn Render>>) -> Self {
+    pub fn new(element: Rc<RefCell<dyn Render>>) -> Self {
         Self {
             element,
-            destination: destination.clone(),
         }
-    }
-}
-
-impl Register for RenderFile {
-    fn register(self) -> Result<Registration, Box<dyn std::error::Error>> {
-        Ok(Registration::Terminal {
-            path: self.destination.clone(),
-            generator: Rc::new(RefCell::new(self)),
-        })
     }
 }
 


### PR DESCRIPTION
RenderFile should not be Register.
Generally we want to avoid overloading Register / Generate.

Register: for declaring targets, including groups of targets, which can Generate.

Generate: for generators which occupy a particular output path.